### PR TITLE
Fix Nyan-Work#45

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.event_name == 'push' && !startsWith(github.event.ref, 'refs/tags/') && contains(github.event.head_commit.message, '[build skip]') == false }}
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,8 +81,7 @@ jobs:
           prerelease: true
           files: |
             LICENSE
-            fabricWrapper/build/libs/*.jar
-            fabricWrapper/build/tmp/submods/META-INF/jars/*.jar
+            versions/*/build/libs/!(*-@(dev|sources|shadow)).jar
           name: "[CI#${{ github.run_number }}]${{ steps.mod_info.outputs.mod_name }} ${{ steps.mod_info.outputs.mod_version }}.${{ steps.get_commit_count.outputs.commit_count }}+${{ steps.get_short_sha.outputs.short_sha }}"
           tag_name: "${{ github.ref_name }}.${{ github.run_number }}"
           target_commitish: ${{ github.event.ref }}

--- a/src/main/java/com/plusls/ommc/impl/feature/sortInventory/SortInventoryHelper.java
+++ b/src/main/java/com/plusls/ommc/impl/feature/sortInventory/SortInventoryHelper.java
@@ -431,8 +431,19 @@ public class SortInventoryHelper {
             //#else
             //$$ CustomData dataA = a.get(DataComponents.CUSTOM_DATA);
             //$$ CustomData dataB = b.get(DataComponents.CUSTOM_DATA);
-            //$$ CompoundTag tagA = dataA.copyTag();
-            //$$ CompoundTag tagB = dataB.copyTag();
+            //$$ CompoundTag tagA, tagB;
+            //$$ if (dataA != null) {
+            //$$     tagA = dataA.copyTag();
+            //$$ }
+            //$$ else{
+            //$$     tagA = null;
+            //$$ }
+            //$$ if (dataB != null) {
+            //$$     tagB = dataB.copyTag();
+            //$$ }
+            //$$ else{
+            //$$     tagB = null;
+            //$$ }
             //#endif
 
             if (ShulkerBoxItemHelper.isShulkerBoxBlockItem(a) && ShulkerBoxItemHelper.isShulkerBoxBlockItem(b) &&

--- a/src/main/java/com/plusls/ommc/mixin/feature/blockModelNoOffset/sodium/MixinBlockRenderer_0_5.java
+++ b/src/main/java/com/plusls/ommc/mixin/feature/blockModelNoOffset/sodium/MixinBlockRenderer_0_5.java
@@ -1,6 +1,5 @@
 package com.plusls.ommc.mixin.feature.blockModelNoOffset.sodium;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.plusls.ommc.impl.feature.blockModelNoOffset.BlockModelNoOffsetHelper;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
 import net.minecraft.world.level.block.state.BlockState;
@@ -11,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependencies;
 import top.hendrixshen.magiclib.api.dependency.annotation.Dependency;
 import top.hendrixshen.magiclib.libs.com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import top.hendrixshen.magiclib.libs.com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
 @Dependencies(require = @Dependency(value = "sodium", versionPredicates = "~0.5"))
 @Pseudo
@@ -24,7 +24,8 @@ public class MixinBlockRenderer_0_5 {
                     target = "Lnet/minecraft/world/level/block/state/BlockState;hasOffsetFunction()Z",
                     ordinal = 0,
                     remap = true
-            )
+            ),
+            remap = false
     )
     private boolean blockModelNoOffset(BlockState blockState, Operation<Boolean> original) {
         if (BlockModelNoOffsetHelper.shouldNoOffset(blockState)) {

--- a/src/main/java/com/plusls/ommc/mixin/feature/disableMoveDownInScaffolding/MixinScaffoldingBlock.java
+++ b/src/main/java/com/plusls/ommc/mixin/feature/disableMoveDownInScaffolding/MixinScaffoldingBlock.java
@@ -36,7 +36,7 @@ public class MixinScaffoldingBlock {
     )
     private void setNormalOutlineShape(BlockState state, BlockGetter world, BlockPos pos,
                                        CollisionContext context, CallbackInfoReturnable<VoxelShape> cir) {
-        if (Configs.disableMoveDownInScaffolding.getBooleanValue() && context.isDescending() &&
+        if (context.isDescending() && Configs.disableMoveDownInScaffolding.getBooleanValue() &&
                 context.isAbove(Shapes.block(), pos, true) &&
                 cir.getReturnValue() != MixinScaffoldingBlock.STABLE_SHAPE) {
 


### PR DESCRIPTION
在 https://github.com/Nyan-Work/oh-my-minecraft-client/issues/45 中有两个bug：
### 与sodium不兼容，启动时出问题
实际上是因为调用`@WrapOperation`的时候使用了`magiclib`的`@WrapOperation`而没有使用`Operation`。

### 在`ModMenu`的界面中滚动时会崩溃
实际上是与`Lithium`的不兼容导致的。在`Lithium`中会提前调用getCollisionShape()的函数，而在OMMC关于脚手架上禁止往下的功能中注入了这个函数，函数开头调用了Configs，这时并没有初始化MinecraftClient，因此对应的handler里初始时获取到的是null值，从而会导致崩溃。

值得注意的是，这个修复的commit实际上比较hacky，可算是临时性的修复。进一步修复可能需要更改上游magiclib的相关函数。

以及以下bug:
### `sortInventory`复制tag时tag可能为空
在`.copyTags()`时可能本身DataComponents就是空的，通过判断DataComponents是不是null修复

### CI need update
java 17的CI系统得稍微升级一下了（虽然只是修修补补，应该直接替换成MasaGadget那种之类的）